### PR TITLE
Add default document to /docs/ns

### DIFF
--- a/docs/ns/index.html
+++ b/docs/ns/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>openWEMI</title>
+    <link rel="alternate" type="text/turtle" href="openWEMI.ttl">
+    <script>
+        window.location = 'openWEMI.html' + window.location.hash;
+    </script>
+  </head>
+  <body>
+      <p>
+          <!-- js disabled -->
+          <a href="openWEMI.html">openWEMI.html</a>
+      </p>
+  </body>
+</html>


### PR DESCRIPTION
Add default document to /docs/ns to handle redirecting extensionless URIs to openWEMI.html and linking to alternate formats, including text/turtle.