### PR TITLE
Removed responsibleEntity from html by hand

### DIFF
--- a/docs/ns/openWEMI.html
+++ b/docs/ns/openWEMI.html
@@ -369,17 +369,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="https://w3id.org/profile/ontdoc/inDomainOf" title="Inverse of rdfs:domain. Defined in Ontology Documentation Profile">In Domain Of</a>
-              </th>
-              <td>
-                <span>
-                  <a href="#responsibleEntity">responsible entity</a>
-                  <sup class="sup-p" title="RDF Property">p</sup>
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="https://w3id.org/profile/ontdoc/superClassOf" title="Inverse of RDFS' subClassOf. Defined in Ontology Documentation Profile">Super Class Of</a>
               </th>
               <td>
@@ -736,44 +725,6 @@ td {
       </div>
       <div class="section" id="properties">
         <h2>Properties</h2>
-        <div class="property entity" id="responsibleEntity">
-          <h3>responsible entity
-            <sup class="sup-p" title="RDF Property">p</sup>
-          </h3>
-          <table>
-            <tr>
-              <th>IRI</th>
-              <td>
-                <code>https://dcmi.github.io/openwemi/ns#responsibleEntity</code>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
-              </th>
-              <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">openWEMI vocabulary</a>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
-              </th>
-              <td><p>One responsible for the creation, production, distribution, maintenance, or ownership of a created entity.</p></td>
-            </tr>
-            <tr>
-              <th>
-                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#domain" title="A domain of the subject property. Defined in The RDF Schema vocabulary (RDFS)">Domain</a>
-              </th>
-              <td>
-                <span>
-                  <a href="#Endeavor">Endeavor</a>
-                  <sup class="sup-c" title="OWL/RDFS Class">c</sup>
-                </span>
-              </td>
-            </tr>
-          </table>
-        </div>
         <div class="property entity" id="relatedWork">
           <h3>related Work
             <sup class="sup-p" title="RDF Property">p</sup>
@@ -1659,9 +1610,6 @@ td {
             <a href="#properties">Properties</a>
           </h4>
           <ul class="second">
-            <li>
-              <a href="#responsibleEntity">responsible entity</a>
-            </li>
             <li>
               <a href="#relatedWork">related Work</a>
             </li>


### PR DESCRIPTION
Since I couldn't get pyLODE to run, I edited openWEMI.html by hand to remove all mentions of the responsibleEntity property which was removed from the .ttl in an earlier change.