### PR TITLE
replacing skos:definition with rdfs:comment

### DIFF
--- a/docs/ns/openWEMI.html
+++ b/docs/ns/openWEMI.html
@@ -363,7 +363,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
               </th>
               <td><p>A creation.</p></td>
             </tr>
@@ -423,7 +423,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
               </th>
               <td><p>An abstract notion of an artistic or intellectual creation.</p></td>
             </tr>
@@ -509,7 +509,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
               </th>
               <td><p>A perceivable form of the creation.</p></td>
             </tr>
@@ -595,7 +595,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
               </th>
               <td><p>The physical embodiment of a creation.</p></td>
             </tr>
@@ -681,7 +681,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
               </th>
               <td><p>An exemplar of a creation.</p></td>
             </tr>
@@ -770,12 +770,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>A Work that is related in some way to another Work.</p></td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
               <td><p>This provides a non-specific relationship between two Works. The specific relationship type can be defined as a sub-property of relatedWork.</p></td>
@@ -833,12 +827,6 @@ td {
               <td>
                 <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
               </td>
-            </tr>
-            <tr>
-              <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>An Expression that is related in some way to another Expression.</p></td>
             </tr>
             <tr>
               <th>
@@ -902,12 +890,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>A Manifestation that is related in some way to another Manifestation.</p></td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
               <td><p>This provides a non-specific relationship between two Manifestations. The specific relationship type can be defined as a sub-property of relatedManifestation.</p></td>
@@ -965,12 +947,6 @@ td {
               <td>
                 <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
               </td>
-            </tr>
-            <tr>
-              <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>An Item that is related in some way to another Item.</p></td>
             </tr>
             <tr>
               <th>
@@ -1034,12 +1010,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>An Endeavor that expresses a Work.</p></td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
               <td><p>A relationship asserted from an Expression to a Work that it expresses.</p></td>
@@ -1100,12 +1070,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>An Expression of a Work.</p></td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
               <td><p>A relationship asserted from a Work to an Expression that expresses the Work.</p></td>
@@ -1163,12 +1127,6 @@ td {
               <td>
                 <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
               </td>
-            </tr>
-            <tr>
-              <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>An Endeavor that manifests an Expression or a Work.</p></td>
             </tr>
             <tr>
               <th>
@@ -1233,12 +1191,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>A Manifestation of a Work or an Expression.</p></td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
               <td><p>A relationship asserted from a Work or an Expression to a Manifestation.</p></td>
@@ -1300,12 +1252,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>An Endeavor that instantiates a Manifestation, an Expression or a Work.</p></td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
               <td><p>A relationship asserted from an Item to a Manifestation, an Expression, or a Work.</p></td>
@@ -1337,10 +1283,10 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#range" title="A range of the subject property. Defined in The RDF Schema vocabulary (RDFS)">Range</a>
               </th>
               <td><span>
-  <a href="#Expression">Expression</a>
+  <a href="#Work">Work</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span> <span class="cardinality">or</span> <span>
-  <a href="#Work">Work</a>
+  <a href="#Expression">Expression</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span> <span class="cardinality">or</span> <span>
   <a href="#Manifestation">Manifestation</a>
@@ -1367,12 +1313,6 @@ td {
               <td>
                 <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
               </td>
-            </tr>
-            <tr>
-              <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>An instantiation of a Manifestation, an Expression or a Work.</p></td>
             </tr>
             <tr>
               <th>
@@ -1440,12 +1380,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>Relates any two resources that are or contain the same endeavor.</p></td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
               <td><p>commonEndeavour is intended to define a relationship between two resources that may or may not be modeled as . This makes it possible to assert that a resource modeled using a vocabulary that does not use the  entity model explicitly is describing the same Work, Expression, Manifestation, and/or Item as another resource.</p></td>
@@ -1470,12 +1404,6 @@ td {
               <td>
                 <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
               </td>
-            </tr>
-            <tr>
-              <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>Relates any two resources that are or contain the same Work.</p></td>
             </tr>
             <tr>
               <th>
@@ -1506,12 +1434,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>Relates any two resources that are or contain the same Expression.</p></td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
               <td><p>commonExpression is intended to define a relationship between two resources that may or may not be modeled as OpenWEMI. This makes it possible to assert that a resource modeled using a vocabulary that does not use the OpenWEMI entity model explicitly is describing the Expression as another resource.</p></td>
@@ -1539,12 +1461,6 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>Relates any two resources that are or contain the same Manifestation.</p></td>
-            </tr>
-            <tr>
-              <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
               <td><p>commonManifestation is intended to define a relationship between two resources that may or may not be modeled as OpenWEMI. This makes it possible to assert that a resource modeled using a vocabulary that does not use the OpenWEMI entity model explicitly is describing the same Manifestation as another resource.</p></td>
@@ -1569,12 +1485,6 @@ td {
               <td>
                 <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
               </td>
-            </tr>
-            <tr>
-              <th>
-                <a class="hover_property" href="http://www.w3.org/2004/02/skos/core#definition" title="A statement or formal explanation of the meaning of a concept. Defined in SKOS Vocabulary">Definition</a>
-              </th>
-              <td><p>Relates any two resources that are or contain the same Item.</p></td>
             </tr>
             <tr>
               <th>
@@ -1655,10 +1565,6 @@ td {
           <dt id="rdfs">rdfs</dt>
           <dd>
             <code>http://www.w3.org/2000/01/rdf-schema#</code>
-          </dd>
-          <dt id="skos">skos</dt>
-          <dd>
-            <code>http://www.w3.org/2004/02/skos/core#</code>
           </dd>
         </dl>
       </div>
@@ -1800,9 +1706,6 @@ td {
             </li>
             <li>
               <a href="#rdfs">rdfs</a>
-            </li>
-            <li>
-              <a href="#skos">skos</a>
             </li>
           </ul>
         </li>

--- a/docs/ns/openWEMI.ttl
+++ b/docs/ns/openWEMI.ttl
@@ -15,13 +15,13 @@ openwemi: a owl:Ontology ;
 openwemi:Endeavor
   a rdfs:Class, owl:Class ;
   rdfs:label "Endeavor"@en ;
-  skos:definition "A creation."@en ;
+  rdfs:comment "A creation."@en ;
   rdfs:isDefinedBy openwemi: .
   
 openwemi:Work
   a rdfs:Class, owl:Class ;
   rdfs:label "Work"@en ;
-  skos:definition "An abstract notion of an artistic or intellectual creation."@en ;
+  rdfs:comment "An abstract notion of an artistic or intellectual creation."@en ;
   rdfs:isDefinedBy openwemi: ;
   dct:description "A work is an abstraction that represents the concepts behind a creation. Each metadata community will have a different definition of Work, but it should be the broadest definition of the creations being described."@en ;
   rdfs:subClassOf openwemi:Endeavor .
@@ -29,7 +29,7 @@ openwemi:Work
 openwemi:Expression
   a rdfs:Class, owl:Class ;
   rdfs:label "Expression"@en ;
-  skos:definition "A perceivable form of the creation."@en ;
+  rdfs:comment "A perceivable form of the creation."@en ;
   rdfs:isDefinedBy openwemi: ;
   dct:description "Creations are made tangible through some kind of expression, such as text, sound, or a visual form. There may be more than one expression of a work of the same type or of different types."@en ;
   rdfs:subClassOf openwemi:Endeavor .
@@ -37,7 +37,7 @@ openwemi:Expression
 openwemi:Manifestation
   a rdfs:Class, owl:Class ;
   rdfs:label "Manifestation"@en ;
-  skos:definition "The physical embodiment of a creation."@en ;
+  rdfs:comment "The physical embodiment of a creation."@en ;
   rdfs:isDefinedBy openwemi: ;
   dct:description "A manifestation is a creation that has been realized in some physical or digital form. A manifestation may be a single realization or a realization that is produced in multiple copies such as the publication of a music compact disk or the manufacture of a shirt."@en ;
   rdfs:subClassOf openwemi:Endeavor .
@@ -45,7 +45,7 @@ openwemi:Manifestation
 openwemi:Item
   a rdfs:Class, owl:Class ;
   rdfs:label "Item"@en ;
-  skos:definition "An exemplar of a creation."@en ;
+  rdfs:comment "An exemplar of a creation."@en ;
   rdfs:isDefinedBy openwemi: ;
   dct:description "An Item is a single instance of the creation, something that can have a place on a shelf or a location online."@en ;
   rdfs:subClassOf openwemi:Endeavor .
@@ -53,7 +53,7 @@ openwemi:Item
 openwemi:relatedWork
   a rdf:Property ;
   rdfs:label "related Work"@en ;
-  skos:definition "A Work that is related in some way to another Work."@en ;
+  rdfs:comment "A Work that is related in some way to another Work."@en ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
   rdfs:domain openwemi:Work ;
@@ -63,7 +63,7 @@ openwemi:relatedWork
 openwemi:relatedExpression
   a rdf:Property ;
   rdfs:label "related Expression"@en ;
-  skos:definition "An Expression that is related in some way to another Expression."@en ;
+  rdfs:comment "An Expression that is related in some way to another Expression."@en ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
   rdfs:domain openwemi:Expression ;
@@ -73,7 +73,7 @@ openwemi:relatedExpression
 openwemi:relatedManifestation
   a rdf:Property ;
   rdfs:label "related Manifestation"@en ;
-  skos:definition "A Manifestation that is related in some way to another Manifestation."@en ;
+  rdfs:comment "A Manifestation that is related in some way to another Manifestation."@en ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
   rdfs:domain openwemi:Manifestation ;
@@ -83,7 +83,7 @@ openwemi:relatedManifestation
 openwemi:relatedItem
   a rdf:Property ;
   rdfs:label "related Item"@en ;
-  skos:definition "An Item that is related in some way to another Item."@en ;
+  rdfs:comment "An Item that is related in some way to another Item."@en ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
   rdfs:domain openwemi:Item ;
@@ -93,7 +93,7 @@ openwemi:relatedItem
 openwemi:expresses
   a rdf:Property ;
   rdfs:label "expresses"@en ;
-  skos:definition "An Endeavor that expresses a Work."@en ;
+  rdfs:comment "An Endeavor that expresses a Work."@en ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
   rdfs:domain openwemi:Expression ;
@@ -103,7 +103,7 @@ openwemi:expresses
  openwemi:expressedBy
   a rdf:Property ;
   rdfs:label "expressed by"@en ;
-  skos:definition "An Expression of a Work."@en ;
+  rdfs:comment "An Expression of a Work."@en ;
   owl:inverseOf openwemi:expresses ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
@@ -114,7 +114,7 @@ openwemi:expresses
 openwemi:manifests
   a rdf:Property ;
   rdfs:label "manifests"@en ;
-  skos:definition "An Endeavor that manifests an Expression or a Work."@en ;
+  rdfs:comment "An Endeavor that manifests an Expression or a Work."@en ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
   rdfs:domain openwemi:Manifestation ;
@@ -130,7 +130,7 @@ openwemi:manifests
 openwemi:manifestedBy
   a rdf:Property ;
   rdfs:label "manifested by"@en ;
-  skos:definition "A Manifestation of a Work or an Expression."@en ;
+  rdfs:comment "A Manifestation of a Work or an Expression."@en ;
   owl:inverseOf openwemi:manifests ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
@@ -147,7 +147,7 @@ openwemi:manifestedBy
 openwemi:instantiates
   a rdf:Property ;
   rdfs:label "instantiates"@en ;
-  skos:definition "An Endeavor that instantiates a Manifestation, an Expression or a Work."@en ;
+  rdfs:comment "An Endeavor that instantiates a Manifestation, an Expression or a Work."@en ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
   rdfs:domain openwemi:Item ;
@@ -164,7 +164,7 @@ openwemi:instantiates
 openwemi:instantiatedBy
   a rdf:Property ;
   rdfs:label "instantiated by"@en ;
-  skos:definition "An instantiation of a Manifestation, an Expression or a Work."@en ;
+  rdfs:comment "An instantiation of a Manifestation, an Expression or a Work."@en ;
   owl:inverseOf openwemi:instantiates ;
   rdfs:isDefinedBy openwemi: ;
   rdfs:subPropertyOf dct:relation ;
@@ -183,7 +183,7 @@ openwemi:commonEndeavor
     a rdf:Property ;
     rdfs:isDefinedBy openwemi: ;
     rdfs:label "common Endeavor"@en ;
-    skos:definition "Relates any two resources that are or contain the same endeavor." ;
+    rdfs:comment "Relates any two resources that are or contain the same endeavor." ;
     dct:description "commonEndeavour is intended to define a relationship between two resources that may or may not be modeled as . This makes it possible to assert that a resource modeled using a vocabulary that does not use the  entity model explicitly is describing the same Work, Expression, Manifestation, and/or Item as another resource."@en ;
     owl:equivalentProperty <http://open.vocab.org/terms/commonEndeavour> .
     
@@ -191,7 +191,7 @@ openwemi:commonWork
     a rdf:Property ;
     rdfs:isDefinedBy openwemi: ;
     rdfs:label "common Work"@en ;
-    skos:definition "Relates any two resources that are or contain the same Work." ;
+    rdfs:comment "Relates any two resources that are or contain the same Work." ;
     dct:description "commonWork is intended to define a relationship between two resources that may or may not be modeled as OpenWEMI. This makes it possible to assert that a resource modeled using a vocabulary that does not use the OpenWEMI entity model explicitly is describing the same Work as another resource."@en ;
         owl:equivalentProperty <http://open.vocab.org/terms/commonWork> .
         
@@ -199,7 +199,7 @@ openwemi:commonExpression
     a rdf:Property ;
     rdfs:isDefinedBy openwemi: ;
     rdfs:label "common Expression"@en ;
-    skos:definition "Relates any two resources that are or contain the same Expression." ;
+    rdfs:comment "Relates any two resources that are or contain the same Expression." ;
     dct:description "commonExpression is intended to define a relationship between two resources that may or may not be modeled as OpenWEMI. This makes it possible to assert that a resource modeled using a vocabulary that does not use the OpenWEMI entity model explicitly is describing the Expression as another resource."@en ;
     owl:equivalentProperty <http://open.vocab.org/terms/commonExpression> .
 
@@ -207,7 +207,7 @@ openwemi:commonManifestation
     a rdf:Property ;
     rdfs:isDefinedBy openwemi: ;
     rdfs:label "common Manifestation"@en ;
-    skos:definition "Relates any two resources that are or contain the same Manifestation." ;
+    rdfs:comment "Relates any two resources that are or contain the same Manifestation." ;
     dct:description "commonManifestation is intended to define a relationship between two resources that may or may not be modeled as OpenWEMI. This makes it possible to assert that a resource modeled using a vocabulary that does not use the OpenWEMI entity model explicitly is describing the same Manifestation as another resource."@en ;
     owl:equivalentProperty <http://open.vocab.org/terms/commonManifestation> .
 
@@ -215,6 +215,6 @@ openwemi:commonItem
     a rdf:Property ;
     rdfs:isDefinedBy openwemi: ;
     rdfs:label "common Item"@en ;
-    skos:definition "Relates any two resources that are or contain the same Item." ;
+    rdfs:comment "Relates any two resources that are or contain the same Item." ;
     dct:description "commonItem is intended to define a relationship between two resources that may or may not be modeled as OpenWEMI. This makes it possible to assert that a resource modeled using a vocabulary that does not use the OpenWEMI entity model explicitly is describing the same Item as another resource."@en ;
     owl:equivalentProperty <http://open.vocab.org/terms/commonItem> .


### PR DESCRIPTION
Replacing all `skos:definition` references with `rdfs:comment`. Note that the label in the HTML documentation reads 'Comments' instead of 'Definition' as the output is based on the property label. Working on a fix...