### PR TITLE
Update rdfs:comment label from comment to definition in OpenWEMI HTML document

### DIFF
--- a/docs/ns/openWEMI.html
+++ b/docs/ns/openWEMI.html
@@ -363,7 +363,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Definition</a>
               </th>
               <td><p>A creation.</p></td>
             </tr>
@@ -423,7 +423,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Definition</a>
               </th>
               <td><p>An abstract notion of an artistic or intellectual creation.</p></td>
             </tr>
@@ -509,7 +509,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Definition</a>
               </th>
               <td><p>A perceivable form of the creation.</p></td>
             </tr>
@@ -595,7 +595,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Definition</a>
               </th>
               <td><p>The physical embodiment of a creation.</p></td>
             </tr>
@@ -681,7 +681,7 @@ td {
             </tr>
             <tr>
               <th>
-                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Comment</a>
+                <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#comment" title="A description of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Definition</a>
               </th>
               <td><p>An exemplar of a creation.</p></td>
             </tr>
@@ -1283,13 +1283,13 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#range" title="A range of the subject property. Defined in The RDF Schema vocabulary (RDFS)">Range</a>
               </th>
               <td><span>
-  <a href="#Work">Work</a>
-  <sup class="sup-c" title="OWL/RDFS Class">c</sup>
-</span> <span class="cardinality">or</span> <span>
   <a href="#Expression">Expression</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span> <span class="cardinality">or</span> <span>
   <a href="#Manifestation">Manifestation</a>
+  <sup class="sup-c" title="OWL/RDFS Class">c</sup>
+</span> <span class="cardinality">or</span> <span>
+  <a href="#Work">Work</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span></td>
             </tr>
@@ -1336,13 +1336,13 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#domain" title="A domain of the subject property. Defined in The RDF Schema vocabulary (RDFS)">Domain</a>
               </th>
               <td><span>
+  <a href="#Work">Work</a>
+  <sup class="sup-c" title="OWL/RDFS Class">c</sup>
+</span> <span class="cardinality">or</span> <span>
   <a href="#Expression">Expression</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span> <span class="cardinality">or</span> <span>
   <a href="#Manifestation">Manifestation</a>
-  <sup class="sup-c" title="OWL/RDFS Class">c</sup>
-</span> <span class="cardinality">or</span> <span>
-  <a href="#Work">Work</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span></td>
             </tr>


### PR DESCRIPTION
Use of the `rdfs:comment` property replaced `skos:definition` in #106. This pull request changes the label that appears for the `rdfs:comment` property from *Comment* to *Definition* in the OpenWEMI HTML document generated by pyLODE. 

