### PR TITLE
Update NS in TTL and HTML

### DIFF
--- a/docs/ns/openWEMI.html
+++ b/docs/ns/openWEMI.html
@@ -283,7 +283,7 @@ td {
     <script id="schema.org" type="application/ld+json">
 [
   {
-    "@id": "https://dcmi.github.io/openwemi/ns#",
+    "@id": "https://ns.dublincore.org/openwemi/",
     "@type": [
       "https://schema.org/DefinedTermSet"
     ],
@@ -317,7 +317,7 @@ td {
               <strong>IRI</strong>
             </dt>
             <dd>
-              <code>https://dcmi.github.io/openwemi/ns#</code>
+              <code>https://ns.dublincore.org/openwemi/</code>
             </dd>
           </div>
           <div>
@@ -350,7 +350,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#Endeavor</code>
+                <code>https://ns.dublincore.org/openwemi/Endeavor</code>
               </td>
             </tr>
             <tr>
@@ -358,7 +358,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -410,7 +410,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#Work</code>
+                <code>https://ns.dublincore.org/openwemi/Work</code>
               </td>
             </tr>
             <tr>
@@ -418,7 +418,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -431,7 +431,7 @@ td {
               <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
-              <td><p>A work is an abstraction that represents the concepts behind a creation. Each metadata community will have a different definition of Work, but it should be the broadest definition of the creations being described.</p></td>
+              <td><p>A work is an abstraction that represents the concepts behind an Endeavor. Each metadata community will have a different definition of Work, but it should be the broadest definition of the Endeavors being described.</p></td>
             </tr>
             <tr>
               <th>
@@ -496,7 +496,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#Expression</code>
+                <code>https://ns.dublincore.org/openwemi/Expression</code>
               </td>
             </tr>
             <tr>
@@ -504,7 +504,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -517,7 +517,7 @@ td {
               <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
-              <td><p>Creations are made tangible through some kind of expression, such as text, sound, or a visual form. There may be more than one expression of a work of the same type or of different types.</p></td>
+              <td><p>Endeavors are made tangible through some kind of expression, such as text, sound, or a visual form. There may be more than one expression of a work of the same type or of different types.</p></td>
             </tr>
             <tr>
               <th>
@@ -582,7 +582,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#Manifestation</code>
+                <code>https://ns.dublincore.org/openwemi/Manifestation</code>
               </td>
             </tr>
             <tr>
@@ -590,7 +590,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -603,7 +603,7 @@ td {
               <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
-              <td><p>A manifestation is a creation that has been realized in some physical or digital form. A manifestation may be a single realization or a realization that is produced in multiple copies such as the publication of a music compact disk or the manufacture of a shirt.</p></td>
+              <td><p>A manifestation is an Endeavor that has been realized in some physical or digital form. A manifestation may be a single realization or a realization that is produced in multiple copies such as the publication of a music compact disk or the manufacture of a shirt.</p></td>
             </tr>
             <tr>
               <th>
@@ -668,7 +668,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#Item</code>
+                <code>https://ns.dublincore.org/openwemi/Item</code>
               </td>
             </tr>
             <tr>
@@ -676,7 +676,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -689,7 +689,7 @@ td {
               <th>
                 <a class="hover_property" href="http://purl.org/dc/terms/description" title="An account of the resource. Defined in DCMI Metadata Terms">Description</a>
               </th>
-              <td><p>An Item is a single instance of the creation, something that can have a place on a shelf or a location online.</p></td>
+              <td><p>An Item is a single instance of an Endeavor, something that can have a place on a shelf or a location online.</p></td>
             </tr>
             <tr>
               <th>
@@ -757,7 +757,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#relatedWork</code>
+                <code>https://ns.dublincore.org/openwemi/relatedWork</code>
               </td>
             </tr>
             <tr>
@@ -765,7 +765,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -817,7 +817,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#relatedExpression</code>
+                <code>https://ns.dublincore.org/openwemi/relatedExpression</code>
               </td>
             </tr>
             <tr>
@@ -825,7 +825,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -877,7 +877,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#relatedManifestation</code>
+                <code>https://ns.dublincore.org/openwemi/relatedManifestation</code>
               </td>
             </tr>
             <tr>
@@ -885,7 +885,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -937,7 +937,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#relatedItem</code>
+                <code>https://ns.dublincore.org/openwemi/relatedItem</code>
               </td>
             </tr>
             <tr>
@@ -945,7 +945,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -997,7 +997,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#expresses</code>
+                <code>https://ns.dublincore.org/openwemi/expresses</code>
               </td>
             </tr>
             <tr>
@@ -1005,7 +1005,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1057,7 +1057,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#expressedBy</code>
+                <code>https://ns.dublincore.org/openwemi/expressedBy</code>
               </td>
             </tr>
             <tr>
@@ -1065,7 +1065,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1117,7 +1117,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#manifests</code>
+                <code>https://ns.dublincore.org/openwemi/manifests</code>
               </td>
             </tr>
             <tr>
@@ -1125,7 +1125,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1161,10 +1161,10 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#range" title="A range of the subject property. Defined in The RDF Schema vocabulary (RDFS)">Range</a>
               </th>
               <td><span>
-  <a href="#Expression">Expression</a>
+  <a href="#Work">Work</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span> <span class="cardinality">or</span> <span>
-  <a href="#Work">Work</a>
+  <a href="#Expression">Expression</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span></td>
             </tr>
@@ -1178,7 +1178,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#manifestedBy</code>
+                <code>https://ns.dublincore.org/openwemi/manifestedBy</code>
               </td>
             </tr>
             <tr>
@@ -1186,7 +1186,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1239,7 +1239,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#instantiates</code>
+                <code>https://ns.dublincore.org/openwemi/instantiates</code>
               </td>
             </tr>
             <tr>
@@ -1247,7 +1247,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1283,13 +1283,13 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#range" title="A range of the subject property. Defined in The RDF Schema vocabulary (RDFS)">Range</a>
               </th>
               <td><span>
-  <a href="#Expression">Expression</a>
+  <a href="#Work">Work</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span> <span class="cardinality">or</span> <span>
   <a href="#Manifestation">Manifestation</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span> <span class="cardinality">or</span> <span>
-  <a href="#Work">Work</a>
+  <a href="#Expression">Expression</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span></td>
             </tr>
@@ -1303,7 +1303,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#instantiatedBy</code>
+                <code>https://ns.dublincore.org/openwemi/instantiatedBy</code>
               </td>
             </tr>
             <tr>
@@ -1311,7 +1311,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1336,13 +1336,13 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#domain" title="A domain of the subject property. Defined in The RDF Schema vocabulary (RDFS)">Domain</a>
               </th>
               <td><span>
-  <a href="#Work">Work</a>
-  <sup class="sup-c" title="OWL/RDFS Class">c</sup>
-</span> <span class="cardinality">or</span> <span>
   <a href="#Expression">Expression</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span> <span class="cardinality">or</span> <span>
   <a href="#Manifestation">Manifestation</a>
+  <sup class="sup-c" title="OWL/RDFS Class">c</sup>
+</span> <span class="cardinality">or</span> <span>
+  <a href="#Work">Work</a>
   <sup class="sup-c" title="OWL/RDFS Class">c</sup>
 </span></td>
             </tr>
@@ -1367,7 +1367,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#commonEndeavor</code>
+                <code>https://ns.dublincore.org/openwemi/commonEndeavor</code>
               </td>
             </tr>
             <tr>
@@ -1375,7 +1375,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1394,7 +1394,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#commonWork</code>
+                <code>https://ns.dublincore.org/openwemi/commonWork</code>
               </td>
             </tr>
             <tr>
@@ -1402,7 +1402,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1421,7 +1421,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#commonExpression</code>
+                <code>https://ns.dublincore.org/openwemi/commonExpression</code>
               </td>
             </tr>
             <tr>
@@ -1429,7 +1429,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1448,7 +1448,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#commonManifestation</code>
+                <code>https://ns.dublincore.org/openwemi/commonManifestation</code>
               </td>
             </tr>
             <tr>
@@ -1456,7 +1456,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1475,7 +1475,7 @@ td {
             <tr>
               <th>IRI</th>
               <td>
-                <code>https://dcmi.github.io/openwemi/ns#commonItem</code>
+                <code>https://ns.dublincore.org/openwemi/commonItem</code>
               </td>
             </tr>
             <tr>
@@ -1483,7 +1483,7 @@ td {
                 <a class="hover_property" href="http://www.w3.org/2000/01/rdf-schema#isDefinedBy" title="The definition of the subject resource. Defined in The RDF Schema vocabulary (RDFS)">Is Defined By</a>
               </th>
               <td>
-                <a href="https://dcmi.github.io/openwemi/ns#">OpenWEMI vocabulary</a>
+                <a href="https://ns.dublincore.org/openwemi/">OpenWEMI vocabulary</a>
               </td>
             </tr>
             <tr>
@@ -1548,7 +1548,7 @@ td {
           </dd>
           <dt id="openwemi">openwemi</dt>
           <dd>
-            <code>https://dcmi.github.io/openwemi/ns#</code>
+            <code>https://ns.dublincore.org/openwemi/</code>
           </dd>
           <dt id="owl">owl</dt>
           <dd>

--- a/docs/ns/openWEMI.ttl
+++ b/docs/ns/openWEMI.ttl
@@ -3,14 +3,13 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix openwemi: <https://dcmi.github.io/openwemi/ns#> .
+@prefix openwemi: <https://ns.dublincore.org/openwemi/> .
 
 openwemi: a owl:Ontology ;
    dct:title "OpenWEMI vocabulary" ;
    dct:creator "Dublin Core Metadata Initiative, OpenWEMI Working Group" ;
    dct:date "2024/01/19" ;
    dct:description "OpenWEMI is a minimally constrained vocabulary for describing created resources using the concepts of Work, Expression, Manifestation, Item." .
-
 
 openwemi:Endeavor
   a rdfs:Class, owl:Class ;


### PR DESCRIPTION
Updated NS reference to: https://ns.dublincore.org/openwemi/ in OpenWEMI TTL and HTML.

OpenWEMI IRIs appear to resolve as expected, see #110.